### PR TITLE
Simplifying DataSource Interface

### DIFF
--- a/ExpenseTracker.xcodeproj/project.pbxproj
+++ b/ExpenseTracker.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		18D775C722AD944400AE281E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 18D775C622AD944400AE281E /* Assets.xcassets */; };
 		18D775CA22AD944400AE281E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 18D775C922AD944400AE281E /* Preview Assets.xcassets */; };
 		18D775D822AD963800AE281E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 18D775DA22AD963800AE281E /* LaunchScreen.storyboard */; };
+		EF5AB75A2C1CBB9C0048EAD1 /* SaveEntryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5AB7592C1CBB9C0048EAD1 /* SaveEntryProtocol.swift */; };
 		EF97F96A2C1B492C00AC5738 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF97F9692C1B492C00AC5738 /* Persistence.swift */; };
 		EF97F96D2C1B71E700AC5738 /* ReportRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF97F96C2C1B71E700AC5738 /* ReportRange.swift */; };
 		EF97F9702C1B8F9E00AC5738 /* ReportReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF97F96F2C1B8F9E00AC5738 /* ReportReader.swift */; };
@@ -36,6 +37,7 @@
 		18D775C922AD944400AE281E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		18D775CE22AD944400AE281E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		18D775DE22AD96B400AE281E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		EF5AB7592C1CBB9C0048EAD1 /* SaveEntryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveEntryProtocol.swift; sourceTree = "<group>"; };
 		EF97F9692C1B492C00AC5738 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		EF97F96C2C1B71E700AC5738 /* ReportRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRange.swift; sourceTree = "<group>"; };
 		EF97F96F2C1B8F9E00AC5738 /* ReportReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportReader.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 			children = (
 				EF97F96F2C1B8F9E00AC5738 /* ReportReader.swift */,
 				EF97F9712C1B8FAB00AC5738 /* ExpenseModelProtocol.swift */,
+				EF5AB7592C1CBB9C0048EAD1 /* SaveEntryProtocol.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -272,6 +275,7 @@
 				EF97F9722C1B8FAB00AC5738 /* ExpenseModelProtocol.swift in Sources */,
 				F5AEF3A325FC2BD700A25CE0 /* AddExpenseView.swift in Sources */,
 				EF97F9772C1B916200AC5738 /* ExpenseModel+Protocol.swift in Sources */,
+				EF5AB75A2C1CBB9C0048EAD1 /* SaveEntryProtocol.swift in Sources */,
 				F52DF9F526013D050047F837 /* ReportsDataSource.swift in Sources */,
 				F5BE6D9E25FD994B0013B09C /* Date.swift in Sources */,
 				EF97F96D2C1B71E700AC5738 /* ReportRange.swift in Sources */,

--- a/ExpenseTracker/Protocols/ReportReader.swift
+++ b/ExpenseTracker/Protocols/ReportReader.swift
@@ -31,3 +31,12 @@
 /// THE SOFTWARE.
 
 import Foundation
+import Combine
+
+class ReportReader: ObservableObject {
+  @Published var currentEntries: [ExpenseModelProtocol] = []
+  func saveEntry(title: String, price: Double, date: Date, comment: String) { }
+  func prepare() {
+    assertionFailure("Missing override: Please override this method in the subclass")
+  }
+}

--- a/ExpenseTracker/Protocols/SaveEntryProtocol.swift
+++ b/ExpenseTracker/Protocols/SaveEntryProtocol.swift
@@ -31,11 +31,7 @@
 /// THE SOFTWARE.
 
 import Foundation
-import Combine
 
-class ReportReader: ObservableObject {
-  @Published var currentEntries: [ExpenseModelProtocol] = []
-  func prepare() {
-    assertionFailure("Missing override: Please override this method in the subclass")
-  }
+protocol SaveEntryProtocol {
+  func saveEntry(title: String, price: Double, date: Date, comment: String)
 }

--- a/ExpenseTracker/Protocols/SaveEntryProtocol.swift
+++ b/ExpenseTracker/Protocols/SaveEntryProtocol.swift
@@ -33,5 +33,5 @@
 import Foundation
 
 protocol SaveEntryProtocol {
-  func saveEntry(title: String, price: Double, date: Date, comment: String)
+  func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool
 }

--- a/ExpenseTracker/Storage/Persistence.swift
+++ b/ExpenseTracker/Storage/Persistence.swift
@@ -40,7 +40,7 @@ struct PersistenceController {
   init(inMemory: Bool = false) {
     container = NSPersistentContainer(name: "ExpensesModel")
 
-    // Use in-memory storage for showing fake date in SwiftUI Previews
+    // Use in-memory storage for showing fake data in SwiftUI Previews
     if inMemory {
       container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
     }
@@ -51,27 +51,4 @@ struct PersistenceController {
       }
     }
   }
-
-  static var preview: PersistenceController = {
-    let result = PersistenceController(inMemory: true)
-    let viewContext = result.container.viewContext
-
-    for index in 0..<5 {
-      let newItem = ExpenseModel(context: viewContext)
-      newItem.title = "Test Title \(index)"
-      newItem.date = Date(timeIntervalSinceNow: Double(index * 60))
-      newItem.comment = "Test Comment \(index)"
-      newItem.price = Double(index + 1) * 12.3
-      newItem.id = UUID()
-    }
-
-    do {
-      try viewContext.save()
-    } catch {
-      let nsError = error as NSError
-      fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-    }
-
-    return result
-  }()
 }

--- a/ExpenseTracker/Storage/ReportsDataSource.swift
+++ b/ExpenseTracker/Storage/ReportsDataSource.swift
@@ -65,7 +65,7 @@ class ReportsDataSource: ReportReader, SaveEntryProtocol {
     }
   }
 
-  func saveEntry(title: String, price: Double, date: Date, comment: String) {
+  func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
     let newItem = ExpenseModel(context: viewContext)
     newItem.title = title
     newItem.date = date
@@ -80,6 +80,7 @@ class ReportsDataSource: ReportReader, SaveEntryProtocol {
     }
 
     try? viewContext.save()
+    return true
   }
 
   func delete(entry: ExpenseModel) {

--- a/ExpenseTracker/Storage/ReportsDataSource.swift
+++ b/ExpenseTracker/Storage/ReportsDataSource.swift
@@ -33,19 +33,18 @@
 import CoreData
 import Combine
 
-class ReportsDataSource: ObservableObject {
+class ReportsDataSource: ReportReader {
   var viewContext: NSManagedObjectContext
   let reportRange: ReportRange
-
-  @Published private(set) var currentEntries: [ExpenseModelProtocol] = []
 
   init(viewContext: NSManagedObjectContext = PersistenceController.shared.container.viewContext, reportRange: ReportRange) {
     self.viewContext = viewContext
     self.reportRange = reportRange
+    super.init()
     prepare()
   }
 
-  func prepare() {
+  override func prepare() {
     currentEntries = getEntries()
   }
 
@@ -66,7 +65,7 @@ class ReportsDataSource: ObservableObject {
     }
   }
 
-  func saveEntry(title: String, price: Double, date: Date, comment: String) {
+  override func saveEntry(title: String, price: Double, date: Date, comment: String) {
     let newItem = ExpenseModel(context: viewContext)
     newItem.title = title
     newItem.date = date

--- a/ExpenseTracker/Storage/ReportsDataSource.swift
+++ b/ExpenseTracker/Storage/ReportsDataSource.swift
@@ -33,7 +33,7 @@
 import CoreData
 import Combine
 
-class ReportsDataSource: ReportReader {
+class ReportsDataSource: ReportReader, SaveEntryProtocol {
   var viewContext: NSManagedObjectContext
   let reportRange: ReportRange
 
@@ -65,7 +65,7 @@ class ReportsDataSource: ReportReader {
     }
   }
 
-  override func saveEntry(title: String, price: Double, date: Date, comment: String) {
+  func saveEntry(title: String, price: Double, date: Date, comment: String) {
     let newItem = ExpenseModel(context: viewContext)
     newItem.title = title
     newItem.date = date

--- a/ExpenseTracker/Views/AddExpenseView.swift
+++ b/ExpenseTracker/Views/AddExpenseView.swift
@@ -82,12 +82,15 @@ struct AddExpenseView: View {
       return
     }
 
-    saveEntryHandler.saveEntry(
+    guard saveEntryHandler.saveEntry(
       title: title,
       price: numericPrice,
       date: time,
       comment: comment
-    )
+    ) else {
+      print("Invalid entry.")
+      return
+    }
     cancelEntry()
   }
 
@@ -106,7 +109,8 @@ struct AddExpenseView: View {
 
 struct AddExpenseView_Previews: PreviewProvider {
   class PreviewSaveHandler: SaveEntryProtocol {
-    func saveEntry(title: String, price: Double, date: Date, comment: String) {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
+      return true
     }
   }
 

--- a/ExpenseTracker/Views/AddExpenseView.swift
+++ b/ExpenseTracker/Views/AddExpenseView.swift
@@ -34,7 +34,7 @@ import SwiftUI
 
 struct AddExpenseView: View {
   @Environment(\.presentationMode) var presentation
-  var saveClosure: (String, Double, Date, String) -> Void
+  var saveEntryHandler: SaveEntryProtocol
 
   @State var title: String = ""
   @State var time = Date()
@@ -82,7 +82,12 @@ struct AddExpenseView: View {
       return
     }
 
-    saveClosure(title, numericPrice, time, comment)
+    saveEntryHandler.saveEntry(
+      title: title,
+      price: numericPrice,
+      date: time,
+      comment: comment
+    )
     cancelEntry()
   }
 
@@ -100,8 +105,12 @@ struct AddExpenseView: View {
 }
 
 struct AddExpenseView_Previews: PreviewProvider {
-  static var previews: some View {
-    AddExpenseView { _, _, _, _ in
+  class PreviewSaveHandler: SaveEntryProtocol {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) {
     }
+  }
+
+  static var previews: some View {
+    AddExpenseView(saveEntryHandler: PreviewSaveHandler())
   }
 }

--- a/ExpenseTracker/Views/ExpensesView.swift
+++ b/ExpenseTracker/Views/ExpensesView.swift
@@ -35,7 +35,7 @@ import Combine
 
 struct ExpensesView: View {
   @State private var isAddPresented = false
-  @ObservedObject var dataSource: ReportsDataSource
+  @ObservedObject var dataSource: ReportReader
 
   var body: some View {
     VStack {
@@ -66,8 +66,41 @@ struct ExpensesView: View {
 }
 
 struct ExpensesView_Previews: PreviewProvider {
+  struct PreviewExpenseEntry: ExpenseModelProtocol {
+    var title: String?
+    var price: Double
+    var comment: String?
+    var date: Date?
+    var id: UUID? = UUID()
+  }
+
+  class PreviewReportsDataSource: ReportReader {
+    override init() {
+      super.init()
+      for index in 1..<6 {
+        saveEntry(
+          title: "Test Title \(index)",
+          price: Double(index + 1) * 12.3,
+          date: Date(timeIntervalSinceNow: Double(index * -60)),
+          comment: "Test Comment \(index)"
+        )
+      }
+    }
+
+    override func prepare() {}
+
+    override func saveEntry(title: String, price: Double, date: Date, comment: String) {
+      let newEntry = PreviewExpenseEntry(
+        title: title,
+        price: price,
+        comment: comment, 
+        date: date
+      )
+      currentEntries.append(newEntry)
+    }
+  }
+
   static var previews: some View {
-    let reportsDataSource = ReportsDataSource(viewContext: PersistenceController.preview.container.viewContext, reportRange: .daily)
-    ExpensesView(dataSource: reportsDataSource)
+    ExpensesView(dataSource: PreviewReportsDataSource())
   }
 }

--- a/ExpenseTracker/Views/ExpensesView.swift
+++ b/ExpenseTracker/Views/ExpensesView.swift
@@ -54,10 +54,11 @@ struct ExpensesView: View {
       })
     }
     .fullScreenCover(
-      isPresented: $isAddPresented) {
-      AddExpenseView { title, price, time, comment in
-        dataSource.saveEntry(title: title, price: price, date: time, comment: comment)
-      }
+      isPresented: $isAddPresented) { () -> AddExpenseView? in
+        guard let saveHandler = dataSource as? SaveEntryProtocol else {
+          return nil
+        }
+        return AddExpenseView(saveEntryHandler: saveHandler)
     }
     .onAppear {
       dataSource.prepare()
@@ -74,7 +75,7 @@ struct ExpensesView_Previews: PreviewProvider {
     var id: UUID? = UUID()
   }
 
-  class PreviewReportsDataSource: ReportReader {
+  class PreviewReportsDataSource: ReportReader, SaveEntryProtocol {
     override init() {
       super.init()
       for index in 1..<6 {
@@ -89,7 +90,7 @@ struct ExpensesView_Previews: PreviewProvider {
 
     override func prepare() {}
 
-    override func saveEntry(title: String, price: Double, date: Date, comment: String) {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) {
       let newEntry = PreviewExpenseEntry(
         title: title,
         price: price,

--- a/ExpenseTracker/Views/ExpensesView.swift
+++ b/ExpenseTracker/Views/ExpensesView.swift
@@ -79,7 +79,7 @@ struct ExpensesView_Previews: PreviewProvider {
     override init() {
       super.init()
       for index in 1..<6 {
-        saveEntry(
+        _ = saveEntry(
           title: "Test Title \(index)",
           price: Double(index + 1) * 12.3,
           date: Date(timeIntervalSinceNow: Double(index * -60)),
@@ -90,7 +90,7 @@ struct ExpensesView_Previews: PreviewProvider {
 
     override func prepare() {}
 
-    func saveEntry(title: String, price: Double, date: Date, comment: String) {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
       let newEntry = PreviewExpenseEntry(
         title: title,
         price: price,
@@ -98,6 +98,7 @@ struct ExpensesView_Previews: PreviewProvider {
         date: date
       )
       currentEntries.append(newEntry)
+      return true
     }
   }
 


### PR DESCRIPTION
This PR also has the goal of applying Dependency Inversion in the ExpenseTracker app.  This time around an abstract class named ReportReader is used to remove the concrete dependencies on ReportsDataSource.

- Add an abstract class ReportReader that conform to ObservableObject and has the currentEntries variable and the methods saveEntry and prepare.
- Have ReportsDataSource inherit from the abstract class ReportReader.
- Remove the declaration of currentEntries since it exists in the super class.
- Override methods prepare() and saveEntry and called super.init.
- Change the dataSource type to the abstract class ReportReader.
- Add a new PreviewExpenseEntry struct that conforms with the ExpenseModelProtocol.
- Add a new PreviewReportsDataSource that inherits from ReportReader and override methods init, prepare and saveEntry.
- Update ExpensesView's previews by using PreviewReportsDataSource to eliminate the need for CoreData and to initialize a preview context.
- Remove the static variable preview in Persistence.swift since we don't need it anymore.
- Fix typo in comment to indicate fake data instead of fake date.