### PR TITLE
Adding Interface Segregation

### DIFF
--- a/ExpenseTracker.xcodeproj/project.pbxproj
+++ b/ExpenseTracker.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		18D775C722AD944400AE281E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 18D775C622AD944400AE281E /* Assets.xcassets */; };
 		18D775CA22AD944400AE281E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 18D775C922AD944400AE281E /* Preview Assets.xcassets */; };
 		18D775D822AD963800AE281E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 18D775DA22AD963800AE281E /* LaunchScreen.storyboard */; };
+		EF5AB75A2C1CBB9C0048EAD1 /* SaveEntryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5AB7592C1CBB9C0048EAD1 /* SaveEntryProtocol.swift */; };
 		EF97F96A2C1B492C00AC5738 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF97F9692C1B492C00AC5738 /* Persistence.swift */; };
 		EF97F96D2C1B71E700AC5738 /* ReportRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF97F96C2C1B71E700AC5738 /* ReportRange.swift */; };
 		EF97F9702C1B8F9E00AC5738 /* ReportReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF97F96F2C1B8F9E00AC5738 /* ReportReader.swift */; };
@@ -36,6 +37,7 @@
 		18D775C922AD944400AE281E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		18D775CE22AD944400AE281E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		18D775DE22AD96B400AE281E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		EF5AB7592C1CBB9C0048EAD1 /* SaveEntryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveEntryProtocol.swift; sourceTree = "<group>"; };
 		EF97F9692C1B492C00AC5738 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		EF97F96C2C1B71E700AC5738 /* ReportRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRange.swift; sourceTree = "<group>"; };
 		EF97F96F2C1B8F9E00AC5738 /* ReportReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportReader.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 			children = (
 				EF97F96F2C1B8F9E00AC5738 /* ReportReader.swift */,
 				EF97F9712C1B8FAB00AC5738 /* ExpenseModelProtocol.swift */,
+				EF5AB7592C1CBB9C0048EAD1 /* SaveEntryProtocol.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -272,6 +275,7 @@
 				EF97F9722C1B8FAB00AC5738 /* ExpenseModelProtocol.swift in Sources */,
 				F5AEF3A325FC2BD700A25CE0 /* AddExpenseView.swift in Sources */,
 				EF97F9772C1B916200AC5738 /* ExpenseModel+Protocol.swift in Sources */,
+				EF5AB75A2C1CBB9C0048EAD1 /* SaveEntryProtocol.swift in Sources */,
 				F52DF9F526013D050047F837 /* ReportsDataSource.swift in Sources */,
 				F5BE6D9E25FD994B0013B09C /* Date.swift in Sources */,
 				EF97F96D2C1B71E700AC5738 /* ReportRange.swift in Sources */,

--- a/ExpenseTracker/Protocols/SaveEntryProtocol.swift
+++ b/ExpenseTracker/Protocols/SaveEntryProtocol.swift
@@ -31,11 +31,7 @@
 /// THE SOFTWARE.
 
 import Foundation
-import Combine
 
-class ReportReader: ObservableObject {
-  @Published var currentEntries: [ExpenseModelProtocol] = []
-  func prepare() {
-    assertionFailure("Missing override: Please override this method in the subclass")
-  }
+protocol SaveEntryProtocol {
+  func saveEntry(title: String, price: Double, date: Date, comment: String)
 }

--- a/ExpenseTracker/Protocols/SaveEntryProtocol.swift
+++ b/ExpenseTracker/Protocols/SaveEntryProtocol.swift
@@ -33,5 +33,5 @@
 import Foundation
 
 protocol SaveEntryProtocol {
-  func saveEntry(title: String, price: Double, date: Date, comment: String)
+  func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool
 }

--- a/ExpenseTracker/Storage/ReportsDataSource.swift
+++ b/ExpenseTracker/Storage/ReportsDataSource.swift
@@ -65,7 +65,7 @@ class ReportsDataSource: ReportReader, SaveEntryProtocol {
     }
   }
 
-  func saveEntry(title: String, price: Double, date: Date, comment: String) {
+  func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
     let newItem = ExpenseModel(context: viewContext)
     newItem.title = title
     newItem.date = date
@@ -80,6 +80,7 @@ class ReportsDataSource: ReportReader, SaveEntryProtocol {
     }
 
     try? viewContext.save()
+    return true
   }
 
   func delete(entry: ExpenseModel) {

--- a/ExpenseTracker/Storage/ReportsDataSource.swift
+++ b/ExpenseTracker/Storage/ReportsDataSource.swift
@@ -33,7 +33,7 @@
 import CoreData
 import Combine
 
-class ReportsDataSource: ReportReader {
+class ReportsDataSource: ReportReader, SaveEntryProtocol {
   var viewContext: NSManagedObjectContext
   let reportRange: ReportRange
 
@@ -65,7 +65,7 @@ class ReportsDataSource: ReportReader {
     }
   }
 
-  override func saveEntry(title: String, price: Double, date: Date, comment: String) {
+  func saveEntry(title: String, price: Double, date: Date, comment: String) {
     let newItem = ExpenseModel(context: viewContext)
     newItem.title = title
     newItem.date = date

--- a/ExpenseTracker/Views/AddExpenseView.swift
+++ b/ExpenseTracker/Views/AddExpenseView.swift
@@ -82,12 +82,15 @@ struct AddExpenseView: View {
       return
     }
 
-    saveEntryHandler.saveEntry(
+    guard saveEntryHandler.saveEntry(
       title: title,
       price: numericPrice,
       date: time,
       comment: comment
-    )
+    ) else {
+      print("Invalid entry.")
+      return
+    }
     cancelEntry()
   }
 
@@ -106,7 +109,8 @@ struct AddExpenseView: View {
 
 struct AddExpenseView_Previews: PreviewProvider {
   class PreviewSaveHandler: SaveEntryProtocol {
-    func saveEntry(title: String, price: Double, date: Date, comment: String) {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
+      return true
     }
   }
 

--- a/ExpenseTracker/Views/AddExpenseView.swift
+++ b/ExpenseTracker/Views/AddExpenseView.swift
@@ -34,7 +34,7 @@ import SwiftUI
 
 struct AddExpenseView: View {
   @Environment(\.presentationMode) var presentation
-  var saveClosure: (String, Double, Date, String) -> Void
+  var saveEntryHandler: SaveEntryProtocol
 
   @State var title: String = ""
   @State var time = Date()
@@ -82,7 +82,12 @@ struct AddExpenseView: View {
       return
     }
 
-    saveClosure(title, numericPrice, time, comment)
+    saveEntryHandler.saveEntry(
+      title: title,
+      price: numericPrice,
+      date: time,
+      comment: comment
+    )
     cancelEntry()
   }
 
@@ -100,8 +105,12 @@ struct AddExpenseView: View {
 }
 
 struct AddExpenseView_Previews: PreviewProvider {
-  static var previews: some View {
-    AddExpenseView { _, _, _, _ in
+  class PreviewSaveHandler: SaveEntryProtocol {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) {
     }
+  }
+
+  static var previews: some View {
+    AddExpenseView(saveEntryHandler: PreviewSaveHandler())
   }
 }

--- a/ExpenseTracker/Views/ExpensesView.swift
+++ b/ExpenseTracker/Views/ExpensesView.swift
@@ -54,10 +54,11 @@ struct ExpensesView: View {
       })
     }
     .fullScreenCover(
-      isPresented: $isAddPresented) {
-      AddExpenseView { title, price, time, comment in
-        dataSource.saveEntry(title: title, price: price, date: time, comment: comment)
-      }
+      isPresented: $isAddPresented) { () -> AddExpenseView? in
+        guard let saveHandler = dataSource as? SaveEntryProtocol else {
+          return nil
+        }
+        return AddExpenseView(saveEntryHandler: saveHandler)
     }
     .onAppear {
       dataSource.prepare()
@@ -74,7 +75,7 @@ struct ExpensesView_Previews: PreviewProvider {
     var id: UUID? = UUID()
   }
 
-  class PreviewReportsDataSource: ReportReader {
+  class PreviewReportsDataSource: ReportReader, SaveEntryProtocol {
     override init() {
       super.init()
       for index in 1..<6 {
@@ -89,7 +90,7 @@ struct ExpensesView_Previews: PreviewProvider {
 
     override func prepare() {}
 
-    override func saveEntry(title: String, price: Double, date: Date, comment: String) {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) {
       let newEntry = PreviewExpenseEntry(
         title: title,
         price: price,

--- a/ExpenseTracker/Views/ExpensesView.swift
+++ b/ExpenseTracker/Views/ExpensesView.swift
@@ -79,7 +79,7 @@ struct ExpensesView_Previews: PreviewProvider {
     override init() {
       super.init()
       for index in 1..<6 {
-        saveEntry(
+        _ = saveEntry(
           title: "Test Title \(index)",
           price: Double(index + 1) * 12.3,
           date: Date(timeIntervalSinceNow: Double(index * -60)),
@@ -90,7 +90,7 @@ struct ExpensesView_Previews: PreviewProvider {
 
     override func prepare() {}
 
-    func saveEntry(title: String, price: Double, date: Date, comment: String) {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
       let newEntry = PreviewExpenseEntry(
         title: title,
         price: price,
@@ -98,6 +98,7 @@ struct ExpensesView_Previews: PreviewProvider {
         date: date
       )
       currentEntries.append(newEntry)
+      return true
     }
   }
 


### PR DESCRIPTION
This PR has the goal of adding Interface Segregation to the ExpenseTracker app.  After creating the new abstract class ReportReader, we can see that it can be broken down into smaller parts.  By creating a new SaveEntryProtocol and having ReportReader conform to it, we can utilize this protocol to only send this behaviour to the AddExpenseView.

- Add new SaveEntryProtocol and add the saveEntry method definition.
- Remove saveEntry(title:price:date:comment:) in ReportReader.swift.
- Make ReportsDataSource conform to SaveEntryProtocol and remove the override on saveEntry(title:price:date:comment:).
- Make PreviewReportsDataSource conform to SaveEntryProtocol and remove the override on saveEntry(title:price:date:comment:).
- In AddExpenseView.swift, replace saveClosure with a new saveEntryHandler of type SaveEntryProtocol.
- In saveEntry(), replace the call to saveClosure with the new saveEntryHandler.
- Update AddExpenseView previews with the new changes.
- Change the fullScreenCover to return an AddExpenseView with a saveHandler derived from type casting the dataSource to a SaveEntryProtocol.