### PR TITLE
Implementing Liskov Substitution

### DIFF
--- a/ExpenseTracker/Protocols/SaveEntryProtocol.swift
+++ b/ExpenseTracker/Protocols/SaveEntryProtocol.swift
@@ -33,5 +33,5 @@
 import Foundation
 
 protocol SaveEntryProtocol {
-  func saveEntry(title: String, price: Double, date: Date, comment: String)
+  func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool
 }

--- a/ExpenseTracker/Storage/ReportsDataSource.swift
+++ b/ExpenseTracker/Storage/ReportsDataSource.swift
@@ -65,7 +65,7 @@ class ReportsDataSource: ReportReader, SaveEntryProtocol {
     }
   }
 
-  func saveEntry(title: String, price: Double, date: Date, comment: String) {
+  func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
     let newItem = ExpenseModel(context: viewContext)
     newItem.title = title
     newItem.date = date
@@ -80,6 +80,7 @@ class ReportsDataSource: ReportReader, SaveEntryProtocol {
     }
 
     try? viewContext.save()
+    return true
   }
 
   func delete(entry: ExpenseModel) {

--- a/ExpenseTracker/Views/AddExpenseView.swift
+++ b/ExpenseTracker/Views/AddExpenseView.swift
@@ -82,12 +82,15 @@ struct AddExpenseView: View {
       return
     }
 
-    saveEntryHandler.saveEntry(
+    guard saveEntryHandler.saveEntry(
       title: title,
       price: numericPrice,
       date: time,
       comment: comment
-    )
+    ) else {
+      print("Invalid entry.")
+      return
+    }
     cancelEntry()
   }
 
@@ -106,7 +109,8 @@ struct AddExpenseView: View {
 
 struct AddExpenseView_Previews: PreviewProvider {
   class PreviewSaveHandler: SaveEntryProtocol {
-    func saveEntry(title: String, price: Double, date: Date, comment: String) {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
+      return true
     }
   }
 

--- a/ExpenseTracker/Views/ExpensesView.swift
+++ b/ExpenseTracker/Views/ExpensesView.swift
@@ -79,7 +79,7 @@ struct ExpensesView_Previews: PreviewProvider {
     override init() {
       super.init()
       for index in 1..<6 {
-        saveEntry(
+        _ = saveEntry(
           title: "Test Title \(index)",
           price: Double(index + 1) * 12.3,
           date: Date(timeIntervalSinceNow: Double(index * -60)),
@@ -90,7 +90,7 @@ struct ExpensesView_Previews: PreviewProvider {
 
     override func prepare() {}
 
-    func saveEntry(title: String, price: Double, date: Date, comment: String) {
+    func saveEntry(title: String, price: Double, date: Date, comment: String) -> Bool {
       let newEntry = PreviewExpenseEntry(
         title: title,
         price: price,
@@ -98,6 +98,7 @@ struct ExpensesView_Previews: PreviewProvider {
         date: date
       )
       currentEntries.append(newEntry)
+      return true
     }
   }
 


### PR DESCRIPTION
This PR has the goal of implementing the Liskov Substitution principle.

Currently, AddExpenseView expects any saving handler to be able to save. It doesn't expect the saving handler to do anything else.

If you present AddExpenseView with another object that conforms to SaveEntryProtocol but performs some validations before storing the entry, it will affect the overall behavior of the app because AddExpenseView doesn't expect this behavior. This means it doesn't follow the Liskov Substitution principle.

For this app, we need to do is to allow saveEntry(title:price:date:comment:) to return a Boolean to confirm whether it saved the value.

- Update the SaveEntryProtocol's saveEntry(title:price:date:comment:) to return a Bool.
- Update ReportsDataSource.swift to match the changes to the SaveEntryProtocol and return true at the end of saveEntry(title: String, price: Double, date: Date, comment: String).
- Update both previews in AddExpenseView.swift and ExpensesView.swift to match the changes to the SaveEntryProtocol.
- Guard against saveEntryHandler.saveEntry in case there's extra validation within the saveEntry method.
- Discard the return boolean when saving the entry.